### PR TITLE
Use rawgit since it supports CORS. #9

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Github Issue Template",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "manifest_version": 2,
   "description": "Backbone for structuring Github Issues",
   "icons": {

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -8,7 +8,7 @@
     "48": "icon48.png"
   },
   "permissions": [
-    "*://raw.github.com/",
+    "*://rawgit.com/",
     "tabs"
   ],
   "content_scripts": [

--- a/chrome/script/new-issue-page.js
+++ b/chrome/script/new-issue-page.js
@@ -1,4 +1,4 @@
-var TEMPLATE_PATH = '//raw.github.com/skidding/github-issue-template/master/template.md';
+var TEMPLATE_PATH = 'https://rawgit.com/skidding/github-issue-template/master/template.md'
 var $ISSUE_TITLE = $('.composer [name="issue[title]"]');
 var $ISSUE_BODY = $('.composer [name="issue[body]"]');
 


### PR DESCRIPTION
Fixes #9. Thanks @catalinmiron for suggesting to use rawgit directly.
